### PR TITLE
Fix leaking texture atlases because glDeleteTextures(..) is never called

### DIFF
--- a/src/texture-atlas.c
+++ b/src/texture-atlas.c
@@ -91,7 +91,7 @@ texture_atlas_delete( texture_atlas_t *self )
     {
         free( self->data );
     }
-    if( !self->id )
+    if( self->id )
     {
         glDeleteTextures( 1, &self->id );
     }


### PR DESCRIPTION
See also: https://code.google.com/p/freetype-gl/issues/detail?id=52
